### PR TITLE
Upgrade ffmpeg features and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,33 @@
-FROM debian:9 AS builder
+FROM buildpack-deps:stretch AS builder
 
 RUN sed -e '/stretch main/d' -i /etc/apt/sources.list && \
   echo "deb http://deb.debian.org/debian stretch main non-free" >> /etc/apt/sources.list
 
 RUN apt-get update && \
   apt-get install -y \
-    autoconf \
-    automake \
-    build-essential \
-    libfdk-aac-dev \
-    libmp3lame-dev \
-    libtheora-dev \
-    libtool \
-    libvorbis-dev \
-    libvpx-dev \
-    libx264-dev \
-    libx265-dev \
-    pkg-config \
-    wget \
-    yasm \
-    zlib1g-dev
+  autoconf \
+  automake \
+  build-essential \
+  libfdk-aac-dev \
+  libmp3lame-dev \
+  libnuma-dev \
+  libopus-dev \
+  libtheora-dev \
+  libtool \
+  libvorbis-dev \
+  libx264-dev \
+  libx265-dev \
+  pkg-config \
+  wget \
+  yasm \
+  zlib1g-dev
+
+# Using the 'buster' version of libvpx-dev to use version 1.7 of libvpx
+RUN echo "deb http://deb.debian.org/debian buster main non-free" >> /etc/apt/sources.list
+
+RUN apt-get update \
+  && apt-get install -y \
+  libvpx-dev 
 
 ARG FFMPEG_VERSION=4.2
 ARG FFMPEG_SHA256SUM=306bde5f411e9ee04352d1d3de41bd3de986e42e2af2a4c44052dce1ada26fb8
@@ -29,21 +37,26 @@ RUN wget -q http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
   echo "${FFMPEG_SHA256SUM}  ffmpeg-${FFMPEG_VERSION}.tar.bz2" | sha256sum -c && \
   tar xf ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
   rm ffmpeg-${FFMPEG_VERSION}.tar.bz2
+COPY ffmpeg-patches ./ffmpeg-patches
 
 WORKDIR /usr/local/src/ffmpeg-${FFMPEG_VERSION}
+RUN cat ../ffmpeg-patches/* | patch -p1
 RUN ./configure \
-    --prefix=/opt/ffmpeg \
-    --disable-doc \
-    --disable-ffplay \
-    --disable-shared \
-    --enable-gpl \
-    --enable-libfdk_aac \
-    --enable-libmp3lame \
-    --enable-libvorbis \
-    --enable-libvpx \
-    --enable-libx264 \
-    --enable-libx265 \
-    --enable-nonfree
+  --prefix=/opt/ffmpeg \
+  --pkg-config-flags="--static" \
+  --disable-doc \
+  --disable-ffplay \
+  --disable-shared \
+  --enable-gpl \
+  --enable-libfdk_aac \
+  --enable-libmp3lame \
+  --enable-libopus \
+  --enable-libvorbis \
+  --enable-libvpx \
+  --enable-libx264 \
+  --enable-libx265 \
+  --enable-openssl \
+  --enable-nonfree
 RUN make
 
 RUN mkdir -p /tmp/ffmpeg.deb.build/DEBIAN
@@ -57,6 +70,9 @@ FROM debian:9-slim
 
 RUN sed -e '/stretch main/d' -i /etc/apt/sources.list && \
   echo "deb http://deb.debian.org/debian stretch main non-free" >> /etc/apt/sources.list
+
+# Using the 'buster' version of libvpx5 to use version 1.7 of the shared libraies
+RUN echo "deb http://deb.debian.org/debian buster main non-free" >> /etc/apt/sources.list
 
 COPY --from=builder /tmp/ffmpeg-*.deb /opt/ffmpeg/
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-A build of [ffmpeg](https://ffmpeg.org) for Debian 9.
+A build of [ffmpeg](https://ffmpeg.org) for Debian 9 (stretch) and Debian 10 (buster).
+
+Docker build commands must be ran at repository root.
+
+i.e. `docker build -t faithlife/ffmpeg:buster -f buster/Dockerfile .`

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -1,0 +1,73 @@
+FROM debian:10 AS builder
+
+RUN sed -e '/uster main/d' -i /etc/apt/sources.list && \
+  echo "deb http://deb.debian.org/debian buster main non-free" >> /etc/apt/sources.list
+
+RUN apt-get update && \
+  apt-get install -y \
+    autoconf \
+    automake \
+    build-essential \
+    ca-certificates \
+    libfdk-aac-dev \
+    libmp3lame-dev \
+    libnuma-dev \
+    libopus-dev \
+    libssl-dev \
+    libtheora-dev \
+    libtool \
+    libvorbis-dev \
+    libvpx-dev \
+    libx264-dev \
+    libx265-dev \
+    pkg-config \
+    wget \
+    yasm \
+    zlib1g-dev
+
+ARG FFMPEG_VERSION=4.2
+ARG FFMPEG_SHA256SUM=306bde5f411e9ee04352d1d3de41bd3de986e42e2af2a4c44052dce1ada26fb8
+
+WORKDIR /usr/local/src
+RUN wget -q http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
+  echo "${FFMPEG_SHA256SUM}  ffmpeg-${FFMPEG_VERSION}.tar.bz2" | sha256sum -c && \
+  tar xf ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
+  rm ffmpeg-${FFMPEG_VERSION}.tar.bz2
+COPY ffmpeg-patches ./ffmpeg-patches
+
+WORKDIR /usr/local/src/ffmpeg-${FFMPEG_VERSION}
+RUN cat ../ffmpeg-patches/* | patch -p1
+RUN ./configure \
+    --prefix=/opt/ffmpeg \
+    --disable-doc \
+    --disable-ffplay \
+    --disable-shared \
+    --enable-gpl \
+    --enable-libfdk_aac \
+    --enable-libmp3lame \
+    --enable-libopus \
+    --enable-libvorbis \
+    --enable-libvpx \
+    --enable-libx264 \
+    --enable-libx265 \
+    --enable-nonfree \
+    --enable-openssl
+RUN make
+
+RUN mkdir -p /tmp/ffmpeg.deb.build/DEBIAN
+RUN make install DESTDIR=/tmp/ffmpeg.deb.build
+
+COPY buster/deb-control /tmp/ffmpeg.deb.build/DEBIAN/control
+RUN sed -i -e "s/@VERSION@/${FFMPEG_VERSION}/ ; s/@BUILD@/$(date +%Y%m%d%H%M%S)/" /tmp/ffmpeg.deb.build/DEBIAN/control
+RUN dpkg -b /tmp/ffmpeg.deb.build /tmp/ffmpeg-${FFMPEG_VERSION}.deb
+
+FROM debian:10-slim
+
+RUN echo "deb http://deb.debian.org/debian buster main non-free" >> /etc/apt/sources.list
+
+COPY --from=builder /tmp/ffmpeg-*.deb /opt/ffmpeg/
+RUN apt-get update && \
+  apt-get install -y /opt/ffmpeg/ffmpeg-*.deb && \
+  rm -rf /var/lib/apt/lists/*
+
+ENV PATH=${PATH}:/opt/ffmpeg/bin

--- a/buster/deb-control
+++ b/buster/deb-control
@@ -1,0 +1,5 @@
+Package: ffmpeg
+Version: @VERSION@-@BUILD@
+Architecture: amd64
+Depends: libfdk-aac1, libmp3lame0, libnuma1, libopus0, libssl1.1, libtheora0, libvorbis0a, libvorbisenc2, libvorbisfile3, libvpx5, libx264-155, libx265-165
+Description: ffmpeg

--- a/deb-control
+++ b/deb-control
@@ -1,5 +1,5 @@
 Package: ffmpeg
 Version: @VERSION@-@BUILD@
 Architecture: amd64
-Depends: libfdk-aac1, libmp3lame0, libtheora0, libvorbis0a, libvorbisenc2, libvorbisfile3, libvpx4, libx264-148, libx265-95
+Depends: libfdk-aac1, libmp3lame0, libtheora0, libvorbis0a, libvorbisenc2, libvorbisfile3, libvpx5, libx264-148, libx265-95, libcurl3, libopus0, libnuma1
 Description: ffmpeg

--- a/deb-control
+++ b/deb-control
@@ -1,5 +1,0 @@
-Package: ffmpeg
-Version: @VERSION@-@BUILD@
-Architecture: amd64
-Depends: libfdk-aac1, libmp3lame0, libtheora0, libvorbis0a, libvorbisenc2, libvorbisfile3, libvpx5, libx264-148, libx265-95, libcurl3, libopus0, libnuma1
-Description: ffmpeg

--- a/ffmpeg-patches/allow-unkown-options-ffprobe.patch
+++ b/ffmpeg-patches/allow-unkown-options-ffprobe.patch
@@ -1,0 +1,14 @@
+diff --git a/fftools/ffprobe.c b/fftools/ffprobe.c
+index 3becb6330e..b2d1ad1b93 100644
+--- a/fftools/ffprobe.c
++++ b/fftools/ffprobe.c
+@@ -2860,8 +2860,7 @@ static int open_input_file(InputFile *ifile, const char *filename)
+     if (scan_all_pmts_set)
+         av_dict_set(&format_opts, "scan_all_pmts", NULL, AV_DICT_MATCH_CASE);
+     if ((t = av_dict_get(format_opts, "", NULL, AV_DICT_IGNORE_SUFFIX))) {
+-        av_log(NULL, AV_LOG_ERROR, "Option %s not found.\n", t->key);
+-        return AVERROR_OPTION_NOT_FOUND;
++        av_log(NULL, AV_LOG_WARNING, "Option %s not found.\n", t->key);
+     }
+ 
+     if (find_stream_info) {

--- a/ffmpeg-patches/fix-rotation-metadata-override-when-transcoding.patch
+++ b/ffmpeg-patches/fix-rotation-metadata-override-when-transcoding.patch
@@ -1,0 +1,20 @@
+diff --git a/fftools/ffmpeg.c b/fftools/ffmpeg.c
+index aa495b5d9e..d69c1d1652 100644
+--- a/fftools/ffmpeg.c
++++ b/fftools/ffmpeg.c
+@@ -3591,6 +3591,15 @@ static int init_output_stream(OutputStream *ost, char *error, int error_len)
+             ost->st->duration = av_rescale_q(ist->st->duration, ist->st->time_base, ost->st->time_base);
+ 
+         ost->st->codec->codec= ost->enc_ctx->codec;
++
++        // Also set the rotation override when transcoding
++        if (ost->rotate_overridden) {
++            uint8_t *sd = av_stream_new_side_data(ost->st, AV_PKT_DATA_DISPLAYMATRIX,
++                                                  sizeof(int32_t) * 9);
++
++            if (sd)
++                av_display_rotation_set((int32_t *)sd, -ost->rotate_override_value);
++       }
+     } else if (ost->stream_copy) {
+         ret = init_output_stream_streamcopy(ost);
+         if (ret < 0)

--- a/ffmpeg-patches/reduce-cache-internal-seek-error-to-warn.patch
+++ b/ffmpeg-patches/reduce-cache-internal-seek-error-to-warn.patch
@@ -1,0 +1,13 @@
+diff --git a/libavformat/cache.c b/libavformat/cache.c
+index 66bbbf54c9..324f013243 100644
+--- a/libavformat/cache.c
++++ b/libavformat/cache.c
+@@ -194,7 +194,7 @@ static int cache_read(URLContext *h, unsigned char *buf, int size)
+     if (c->logical_pos != c->inner_pos) {
+         r = ffurl_seek(c->inner, c->logical_pos, SEEK_SET);
+         if (r<0) {
+-            av_log(h, AV_LOG_ERROR, "Failed to perform internal seek\n");
++            av_log(h, AV_LOG_WARNING, "Failed to perform internal seek\n");
+             return r;
+         }
+         c->inner_pos = r;

--- a/ffmpeg-patches/reduce-monotonic-dts-error-to-warn.patch
+++ b/ffmpeg-patches/reduce-monotonic-dts-error-to-warn.patch
@@ -1,0 +1,15 @@
+diff -ru ffmpeg-3.4/libavformat/mux.c ffmpeg-patched/libavformat/mux.c
+--- ffmpeg-3.4/libavformat/mux.c	2017-10-15 08:59:38.000000000 -0700
++++ ffmpeg-patched/libavformat/mux.c	2017-10-31 16:06:35.000000000 -0700
+@@ -640,10 +640,9 @@
+           st->codecpar->codec_type != AVMEDIA_TYPE_SUBTITLE &&
+           st->codecpar->codec_type != AVMEDIA_TYPE_DATA &&
+           st->cur_dts >= pkt->dts) || st->cur_dts > pkt->dts)) {
+-        av_log(s, AV_LOG_ERROR,
++        av_log(s, AV_LOG_WARNING,
+                "Application provided invalid, non monotonically increasing dts to muxer in stream %d: %s >= %s\n",
+                st->index, av_ts2str(st->cur_dts), av_ts2str(pkt->dts));
+-        return AVERROR(EINVAL);
+     }
+     if (pkt->dts != AV_NOPTS_VALUE && pkt->pts != AV_NOPTS_VALUE && pkt->pts < pkt->dts) {
+         av_log(s, AV_LOG_ERROR,

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -1,33 +1,29 @@
-FROM buildpack-deps:stretch AS builder
+FROM debian:9 AS builder
 
 RUN sed -e '/stretch main/d' -i /etc/apt/sources.list && \
   echo "deb http://deb.debian.org/debian stretch main non-free" >> /etc/apt/sources.list
 
 RUN apt-get update && \
   apt-get install -y \
-  autoconf \
-  automake \
-  build-essential \
-  libfdk-aac-dev \
-  libmp3lame-dev \
-  libnuma-dev \
-  libopus-dev \
-  libtheora-dev \
-  libtool \
-  libvorbis-dev \
-  libx264-dev \
-  libx265-dev \
-  pkg-config \
-  wget \
-  yasm \
-  zlib1g-dev
-
-# Using the 'buster' version of libvpx-dev to use version 1.7 of libvpx
-RUN echo "deb http://deb.debian.org/debian buster main non-free" >> /etc/apt/sources.list
-
-RUN apt-get update \
-  && apt-get install -y \
-  libvpx-dev 
+    autoconf \
+    automake \
+    build-essential \
+    ca-certificates \
+    libfdk-aac-dev \
+    libmp3lame-dev \
+    libnuma-dev \
+    libopus-dev \
+    libssl-dev \
+    libtheora-dev \
+    libtool \
+    libvorbis-dev \
+    libvpx-dev \
+    libx264-dev \
+    libx265-dev \
+    pkg-config \
+    wget \
+    yasm \
+    zlib1g-dev
 
 ARG FFMPEG_VERSION=4.2
 ARG FFMPEG_SHA256SUM=306bde5f411e9ee04352d1d3de41bd3de986e42e2af2a4c44052dce1ada26fb8
@@ -42,27 +38,26 @@ COPY ffmpeg-patches ./ffmpeg-patches
 WORKDIR /usr/local/src/ffmpeg-${FFMPEG_VERSION}
 RUN cat ../ffmpeg-patches/* | patch -p1
 RUN ./configure \
-  --prefix=/opt/ffmpeg \
-  --pkg-config-flags="--static" \
-  --disable-doc \
-  --disable-ffplay \
-  --disable-shared \
-  --enable-gpl \
-  --enable-libfdk_aac \
-  --enable-libmp3lame \
-  --enable-libopus \
-  --enable-libvorbis \
-  --enable-libvpx \
-  --enable-libx264 \
-  --enable-libx265 \
-  --enable-openssl \
-  --enable-nonfree
+    --prefix=/opt/ffmpeg \
+    --disable-doc \
+    --disable-ffplay \
+    --disable-shared \
+    --enable-gpl \
+    --enable-libfdk_aac \
+    --enable-libmp3lame \
+    --enable-libopus \
+    --enable-libvorbis \
+    --enable-libvpx \
+    --enable-libx264 \
+    --enable-libx265 \
+    --enable-nonfree \
+    --enable-openssl
 RUN make
 
 RUN mkdir -p /tmp/ffmpeg.deb.build/DEBIAN
 RUN make install DESTDIR=/tmp/ffmpeg.deb.build
 
-COPY deb-control /tmp/ffmpeg.deb.build/DEBIAN/control
+COPY stretch/deb-control /tmp/ffmpeg.deb.build/DEBIAN/control
 RUN sed -i -e "s/@VERSION@/${FFMPEG_VERSION}/ ; s/@BUILD@/$(date +%Y%m%d%H%M%S)/" /tmp/ffmpeg.deb.build/DEBIAN/control
 RUN dpkg -b /tmp/ffmpeg.deb.build /tmp/ffmpeg-${FFMPEG_VERSION}.deb
 
@@ -70,9 +65,6 @@ FROM debian:9-slim
 
 RUN sed -e '/stretch main/d' -i /etc/apt/sources.list && \
   echo "deb http://deb.debian.org/debian stretch main non-free" >> /etc/apt/sources.list
-
-# Using the 'buster' version of libvpx5 to use version 1.7 of the shared libraies
-RUN echo "deb http://deb.debian.org/debian buster main non-free" >> /etc/apt/sources.list
 
 COPY --from=builder /tmp/ffmpeg-*.deb /opt/ffmpeg/
 RUN apt-get update && \

--- a/stretch/deb-control
+++ b/stretch/deb-control
@@ -1,0 +1,5 @@
+Package: ffmpeg
+Version: @VERSION@-@BUILD@
+Architecture: amd64
+Depends: libfdk-aac1, libmp3lame0, libnuma1, libopus0, libssl1.1, libtheora0, libvorbis0a, libvorbisenc2, libvorbisfile3, libvpx4, libx264-148, libx265-95
+Description: ffmpeg


### PR DESCRIPTION
Add the ffmpeg patches that are used in Faithlife products.

Upgade the Failthlife ffmpeg build to include a few additional enabled features. Add openssl, opus, and extended vp8/vp9 support.

The extended vorbis support requires libvpx5 which is available from debian's buster libraries.