### PR TITLE
Add libzimg to ffmpeg build and link statically

### DIFF
--- a/4.2/buster-vpx1.8/Dockerfile
+++ b/4.2/buster-vpx1.8/Dockerfile
@@ -37,19 +37,35 @@ RUN gbp buildpackage --git-ignore-branch --git-no-pristine-tar --git-builder="de
 WORKDIR /usr/local/src
 RUN apt-get install ./libvpx6_*_amd64.deb ./libvpx-dev_*_amd64.deb
 
+ARG ZIMG_VERSION=3.0.1
+ARG ZIMG_SHA256SUM=c50a0922f4adac4efad77427d13520ed89b8366eef0ef2fa379572951afcc73f
+
 ARG FFMPEG_VERSION=4.2.2
 ARG FFMPEG_SHA256SUM=b620d187c26f76ca19e74210a0336c3b8380b97730df5cdf45f3e69e89000e5c
 
 WORKDIR /usr/local/src
+
+RUN wget -q -O libzimg.tar.gz https://github.com/sekrit-twc/zimg/archive/release-${ZIMG_VERSION}.tar.gz && \
+  echo "${ZIMG_SHA256SUM} libzimg.tar.gz" | sha256sum -c && \
+  tar xf libzimg.tar.gz && \
+  rm libzimg.tar.gz
+
 RUN wget -q http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
   echo "${FFMPEG_SHA256SUM}  ffmpeg-${FFMPEG_VERSION}.tar.bz2" | sha256sum -c && \
   tar xf ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
   rm ffmpeg-${FFMPEG_VERSION}.tar.bz2
 COPY ffmpeg-patches ./ffmpeg-patches
 
+WORKDIR /usr/local/src/zimg-release-${ZIMG_VERSION}
+RUN ./autogen.sh && \
+  ./configure --enable-static --disable-shared && \
+  make install
+
 WORKDIR /usr/local/src/ffmpeg-${FFMPEG_VERSION}
 RUN cat ../ffmpeg-patches/* | patch -p1
 RUN ./configure \
+    --pkg-config-flags="--static" \
+    --extra-libs="-lm" \
     --prefix=/opt/ffmpeg \
     --disable-doc \
     --disable-ffplay \
@@ -63,6 +79,7 @@ RUN ./configure \
     --enable-libvpx \
     --enable-libx264 \
     --enable-libx265 \
+    --enable-libzimg \
     --enable-nonfree \
     --enable-openssl
 RUN make


### PR DESCRIPTION
I honestly don't know what `--extra-libs="-lm"` is doing here, but after *extensive* testing, that was the one thing that made static linking work
